### PR TITLE
fix init to run superwrapper only once

### DIFF
--- a/addon/mixins/child.js
+++ b/addon/mixins/child.js
@@ -17,7 +17,6 @@ export default Mixin.create({
   },
 
   initChild() {
-    this._super(...arguments);
     this.registerWithParent();
   },
 

--- a/addon/mixins/parent.js
+++ b/addon/mixins/parent.js
@@ -10,7 +10,6 @@ export default Mixin.create({
   },
 
   initParent() {
-    this._super(...arguments);
     this.childComponents = new A();
   },
 

--- a/tests/integration/components/misc-test.js
+++ b/tests/integration/components/misc-test.js
@@ -4,7 +4,7 @@ import test from 'ember-sinon-qunit/test-support/test';
 import hbs from 'htmlbars-inline-precompile';
 import { ParentMixin, ChildMixin } from 'ember-composability-tools';
 
-const { Component } = Ember;
+const { Component, computed, get, set } = Ember;
 
 moduleForComponent('misc', 'Integration | Component | misc', {
   integration: true,
@@ -55,4 +55,32 @@ test('child component with `shouldRegister=false` doesn\'t register to parent', 
   assert.ok(parentSpy.calledOnce, 'parent didInsertParent was called once');
   assert.ok(childSpy.calledOnce, 'child didInsertParent was called once');
   assert.ok(parentSpy.calledBefore(childSpy), 'parent was called before child');
+});
+
+moduleForComponent('misc', 'Integration | Component | misc init', {
+  integration: true
+});
+
+test('init super is called only once per mixin', function(assert) {
+  const customizedObject = Ember.Object.extend({
+    init() {
+      const timesCalled = get(this, 'timesCalled');
+      set(this, 'timesCalled', timesCalled + 1);
+    },
+    timesCalled: computed({
+      get() {
+        return 0;
+      }
+    })
+  });
+  const parentObject = customizedObject.extend(ParentMixin, { });
+  const childObject = customizedObject.extend(ChildMixin, {
+    parentComponent: null,
+    registerWithParent() {}
+  });
+  const parentInstance = parentObject.create();
+  const childInstance = childObject.create();
+
+  assert.equal(get(parentInstance, 'timesCalled'), 1, 'Should call parent init super wrapper only once');
+  assert.equal(get(childInstance, 'timesCalled'), 1, 'Should call child init super wrapper only once');
 });


### PR DESCRIPTION
Previously it would run twice which would completely break `paper-button` with icons for `ember-paper > v1.0.0-alpha.10` by causing infinite loop in `ember-hammertime` (adding it style `attributeBindings` twice and starting to rely on just added one https://github.com/html-next/ember-hammertime/blob/master/addon/mixins/touch-action.js#L85 as the `otherStyleKey` which leads to infinite loop) 