### PR TITLE
Removed deprecated use of 'A' as a constructor

### DIFF
--- a/addon/mixins/parent.js
+++ b/addon/mixins/parent.js
@@ -11,7 +11,7 @@ export default Mixin.create({
   },
 
   initParent() {
-    this.childComponents = new A();
+    this.childComponents = A();
   },
 
   didInsertElement() {


### PR DESCRIPTION
This addon now issues a deprecation warning due to the use of `A()` as a constructor,
details:
[deprecations - new array](https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_array-new-array-wrapper)