### PR TITLE
Remove new call on EmberArray

### DIFF
--- a/addon/mixins/parent.js
+++ b/addon/mixins/parent.js
@@ -11,7 +11,7 @@ export default Mixin.create({
   },
 
   initParent() {
-    this.childComponents = new A();
+    this.childComponents = A();
   },
 
   didInsertElement() {


### PR DESCRIPTION
Straight forward change to avoid [ember deprecation](https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_array-new-array-wrapper).

Fixes #21 