### PR TITLE
Fixes deprecation by adding getter and setter to computed property

### DIFF
--- a/addon/mixins/child.js
+++ b/addon/mixins/child.js
@@ -7,7 +7,7 @@ export default Mixin.create({
 
   // This is intended as an escape hatch, but ideally you would
   // `{{yield` a child contextual component with `parentComponent=this`
-  parentComponent: computed(function() {
+  parentComponent: computed({
     get() {
       if (this._parentComponent) {
         return this._parentComponent;

--- a/addon/mixins/child.js
+++ b/addon/mixins/child.js
@@ -8,7 +8,17 @@ export default Mixin.create({
   // This is intended as an escape hatch, but ideally you would
   // `{{yield` a child contextual component with `parentComponent=this`
   parentComponent: computed(function() {
-    return this.nearestOfType(ParentMixin);
+    get() {
+      if (this._parentComponent) {
+        return this._parentComponent;
+      }
+
+      return this.nearestOfType(ParentMixin);
+    },
+
+    set(key, value) {
+      return this._parentComponent = value;
+    }
   }),
 
   init() {


### PR DESCRIPTION
Fixes #23 by converting computed value parentComponent to use getter/setter when overriding its value in handlebars.