### PR TITLE
Make the addon promise aware

### DIFF
--- a/addon/components/node.js
+++ b/addon/components/node.js
@@ -57,10 +57,10 @@ export default class Node extends Component {
    * @param {HTMLElement} element the root element
    */
   @action
-  didInsertNode(element) {
-    this.setup(element);
+  async didInsertNode(element) {
+    await this.setup(element);
 
-    this.children.forEach((c) => c.didInsertNode(element));
+    this.children.forEach(async (c) => await c.didInsertNode(element));
   }
 
   /**
@@ -79,14 +79,14 @@ export default class Node extends Component {
    * The actual setup logic
    * @param {HTMLElement} element
    */
-  setup(element) {
+  async setup(element) {
     // library setup code goes here
     if (typeof this.args.didInsertParent === 'function') {
-      this.args.didInsertParent(element);
+      await this.args.didInsertParent(element);
     }
 
     if (typeof this.didInsertParent === 'function') {
-      this.didInsertParent(element);
+      await this.didInsertParent(element);
     }
 
     this._didSetup = true;


### PR DESCRIPTION
This makes it so that asyncronous setup in a parent component will be `await`ed before trying to setup child components.

If any given `didInsertNode`/`didInsertParent` functions are NOT marked with `async` then I _think_ this change should have no effect on them.

Fixes #57 

Example usage:

`test/parent.hbs`
```handlebars
<div
  {{!--
  These two actions are inherited from Root, but we need to call them
  manually since we're not using the Root template.
  --}}
  {{did-insert this.didInsertNode}}
  {{will-destroy this.willDestroyNode}}
  ...attributes
>
  <div>The parent</div>
  {{yield (component "Test/Child" parent=this)}}
</div>
```

`test/parent.js`
```javascript
import { Root } from 'ember-composability-tools';

export default class TestParentComponent extends Root {
  @tracked isReady = false;

  // this doesn't need to be an action since it's called directly by Root
  async didInsertParent(element) {
    console.log('Parent: didInsertParent', this.args.id);
    // This simulates an async setup process
    await timeout(this.args.setupTime || 0);
    this.isReady = true;
    console.log('Parent: finally ready', this.args.id);
  }
}
```

`test/child.hbs`
```handlebars
<div>The child</div>
```

`test/child.js`
```javascript
import { Node } from 'ember-composability-tools';

export default class TestChildComponent extends Node {
  parentIsReady(){
    console.log('Child: parent is ready', this.args.id);
  }

  // this doesn't need to be an action since it's called directly by Node
  didInsertParent(element) {
    console.log('Child: didInsertParent', this.args.id, this.args.parent.isReady);
  }
}
```

`test.hbs`
```handlebars
<Test::Parent @id="p1" @setupTime={{1000}} as |Test::Child|>
  <Test::Child @id="c1.1"/>
  <Test::Child @id="c1.2"/>
</Test::Parent>

<Test::Parent @id="p2" @setupTime={{100}} as |Test::Child|>
  <Test::Child @id="c2.1"/>
  <Test::Child @id="c2.2"/>
</Test::Parent>
```

Console output with this PR:
```
// immediately
Parent: didInsertParent p1
Parent: didInsertParent p2

// after 100 ms
Parent: finally ready p2
Child: didInsertParent c2.1
Child: parent is ready c2.1
Child: didInsertParent c2.2
Child: parent is ready c2.2

// after 1000 ms
Parent: finally ready p1
Child: didInsertParent c1.1
Child: parent is ready c1.1
Child: didInsertParent c1.2
Child: parent is ready c1.2
```

Console output without this PR:
```
// immediately
Parent: didInsertParent p1
Child: didInsertParent c1.1
Child: didInsertParent c1.2
Parent: didInsertParent p2
Child: didInsertParent c2.1
Child: didInsertParent c2.2

// after 100 ms
Parent: finally ready p2

// after 1000 ms
Parent: finally ready p1
```