### PR TITLE
Add tests for dealing with async callbacks

### DIFF
--- a/addon/components/node.js
+++ b/addon/components/node.js
@@ -60,7 +60,9 @@ export default class Node extends Component {
   async didInsertNode(element) {
     await this.setup(element);
 
-    await Promise.all([...this.children].map((c) => c.didInsertNode(element)));
+    for(let child of [...this.children]){
+      await child.didInsertNode(element);
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ember-template-lint": "^5.11.2",
     "ember-try": "^3.0.0",
     "eslint": "^8.47.0",
+    "ember-concurrency": "^2.3.7",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^11.10.0",
     "eslint-plugin-n": "^16.0.1",


### PR DESCRIPTION
This adds a test to ensure that callbacks are called in the correct order, and it alters the way that `didInsertNode` is called on child elements. Previously they'd all be fired off at the same time, and would race to finish, and `Promise.all` would ensure that the all finished before proceeding. With this change we `await` each individual child to ensure that they get called in the right order.

I'm not entirely sure if the children being called in the right order is important. If it's not, then we could go back to using `Promise.all` and could adjust the test accordingly.

(For my purposes the children being called in order is not important. It's only important that the child callbacks are called after the _parent_ callback has completed.)